### PR TITLE
Fix 'Content-Lenght' header after encoding

### DIFF
--- a/lib/SOAP/Transport/HTTP.pm
+++ b/lib/SOAP/Transport/HTTP.pm
@@ -217,6 +217,7 @@ sub send_receive {
             else {
                 require Encode;
                 $envelope = Encode::encode($encoding, $envelope);
+                $bytelength = SOAP::Utils::bytelength($envelope);
             }
             #  if !$SOAP::Constants::DO_NOT_USE_LWP_LENGTH_HACK
             #      && length($envelope) != $bytelength;


### PR DESCRIPTION
Proposal for  fixing wrong 'Content-Length' header if the envelope contains wide characters #2.The length of the envolope might have changed after the encoding.  For example, UTF8 is variable-width 
encoding and each character might consist of 1-4 bytes