### PR TITLE
Re-instate utf8 check for as_base64Binary

### DIFF
--- a/lib/SOAP/Lite.pm
+++ b/lib/SOAP/Lite.pm
@@ -806,7 +806,7 @@ sub new {
     } => $class;
     $self->typelookup({
            'base64Binary' =>
-              [10, sub { $_[0] =~ /[^\x09\x0a\x0d\x20-\x7f]/ }, 'as_base64Binary'],
+              [10, sub { !utf8::is_utf8($_[0]) && $_[0] =~ /[^\x09\x0a\x0d\x20-\x7f]/ }, 'as_base64Binary'],
            'zerostring' =>
                [12, sub { $_[0] =~ /^0\d+$/ }, 'as_string'],
             # int (and actually long too) are subtle: the negative range is one greater...

--- a/t/rt78588.t
+++ b/t/rt78588.t
@@ -1,0 +1,23 @@
+use strict;
+use warnings;
+
+use Test::More;
+use SOAP::Lite;
+use utf8;
+use open ":encoding(utf-8)";
+
+my $data = "mü\x{2013}";
+my $serializer = SOAP::Serializer->new();
+
+my $xml = $serializer->envelope( freeform => $data );
+my ( $cycled ) = values %{ SOAP::Deserializer->deserialize( $xml )->body };
+is( $data, $cycled, "UTF-8 string is the same after serializing" );
+
+
+$data = "\x{FF}" x 256;
+$xml = $serializer->envelope( freeform => $data );
+( $cycled ) = values %{ SOAP::Deserializer->deserialize( $xml )->body };
+is( $data, $cycled, "Binary data is the same after serializing" );
+
+
+done_testing;


### PR DESCRIPTION
So the utf8 check was removed, but I believe it needs to go back. I've amended the test t/rt78588.t to have utf8 encoded and binary data - and it passes. 
I can see that this might generate discussion :-)
