### PR TITLE
Extract conditional into subclass

### DIFF
--- a/Changes
+++ b/Changes
@@ -14,6 +14,8 @@ http://rt.cpan.org/Public/Dist/Display.html?Name=SOAP-Lite
 -----------------------------------------------------------------------
 THIS RELEASE
 -----------------------------------------------------------------------
+1.28 August 22th
+    ! Extracted CGI transport conditional read into subclass
 
 1.27 May 14, 2018
     ! Problem with compression in server mode

--- a/lib/SOAP/Transport/HTTP.pm
+++ b/lib/SOAP/Transport/HTTP.pm
@@ -558,6 +558,39 @@ sub make_response {
     $self->SUPER::make_response(@_);
 }
 
+sub read_from_client_chunked {
+    my ($self) = @_;
+
+    my $content = '';
+
+    my $buffer;
+    binmode(STDIN);
+
+    while ( sysread( STDIN, my $buffer, 1024 ) ) {
+        $content .= $buffer;
+    }
+
+    return $content;
+
+}
+
+sub read_from_client {
+    my ($self, $length) = @_;
+
+    my $content = '';
+
+    my $buffer;
+    binmode(STDIN);
+
+    while ( sysread( STDIN, $buffer, $length ) ) {
+        $content .= $buffer;
+        last if ( length($content) >= $length );
+    }
+
+    return $content;
+
+}
+
 sub handle {
     my $self = shift->new;
 
@@ -572,6 +605,7 @@ sub handle {
     my $content = q{};
 
     if ($chunked) {
+        # $self -> read_from_client_chunked();
         my $buffer;
         binmode(STDIN);
         while ( read( STDIN, my $buffer, 1024 ) ) {
@@ -594,6 +628,7 @@ sub handle {
 
         #my $content = q{};
         if ( !$chunked ) {
+            # $self -> read_from_client($length);
             my $buffer;
             binmode(STDIN);
             if ( defined $ENV{'MOD_PERL'} ) {

--- a/t/SOAP/Transport/HTTP.t
+++ b/t/SOAP/Transport/HTTP.t
@@ -70,6 +70,15 @@ isa_ok $server, 'SOAP::Server';
 
 test_make_fault($server);
 
+# package SOAP::Transport::HTTP::CGI::Persistent;
+
+ok $server = SOAP::Transport::HTTP::CGI::Persistent->new();
+isa_ok $server, 'SOAP::Transport::HTTP::CGI';
+isa_ok $server, 'SOAP::Transport::HTTP::Server';
+isa_ok $server, 'SOAP::Server';
+
+test_make_fault($server);
+
 # package SOAP::Transport::HTTP::Daemon
 my $transport;
 

--- a/t/SOAP/Transport/HTTP/CGI/Persistent/test_server.pl
+++ b/t/SOAP/Transport/HTTP/CGI/Persistent/test_server.pl
@@ -8,7 +8,7 @@ use Encode;
 use SOAP::Lite;
 use SOAP::Transport::HTTP;
 
-my $soap = SOAP::Transport::HTTP::CGI->new(
+my $soap = SOAP::Transport::HTTP::CGI::Persistent->new(
     dispatch_to => 'main'
 );
 


### PR DESCRIPTION
The idea behind this is being able to use read instead sysread but not depending on MOD_PERL environment variable.
For instante when using CGI::Compile under plack "read" should be used instead of "sysread" but forcing MOD_PERL variable may cause many other side effects.
