### PR TITLE
Locally eliminate Cygwin special env variables from %ENV

### DIFF
--- a/lib/SOAP/Transport/HTTP.pm
+++ b/lib/SOAP/Transport/HTTP.pm
@@ -626,6 +626,14 @@ sub handle {
             $content .= $self -> read_from_client($length);
         }
 
+        # Cygwin has special environment variables like !:: or !C:
+        local %ENV = %ENV;
+        if ($^O eq 'cygwin') {
+            for my $key (keys %ENV) {
+                delete $ENV{$key} if $key =~ /^!/;
+            }
+        }
+
         $self->request(
             HTTP::Request->new(
                 $ENV{'REQUEST_METHOD'} || '' => $ENV{'SCRIPT_NAME'},


### PR DESCRIPTION
Fix on #14.

```
## On Cygwin 3.1.7
$ prove -blv t/SOAP/Transport/HTTP/CGI.t
t/SOAP/Transport/HTTP/CGI.t ..
ok 1 - return utf8 string
ok 2 - utf8 content: Uberall
1..2
ok
All tests successful.
Files=1, Tests=2,  1 wallclock secs ( 0.02 usr  0.03 sys +  0.16 cusr  0.12 csys =  0.33 CPU)
Result: PASS
```